### PR TITLE
Fix: Normalizing stacked model embeddings

### DIFF
--- a/experimentation/model_factory.py
+++ b/experimentation/model_factory.py
@@ -45,38 +45,45 @@ class LocallyCachedModel(AbstractModel):
 
         ds = datasets.concatenate_datasets([main, embeddings], axis=1)
         self.df = ds.to_pandas().drop_duplicates(subset=["text"]).set_index("text")
+        self.num_models  = 1
     
     def encode(self, sentences, batch_size=32, **kwargs):
         # As efficient as possible
         embeddings = self.df.loc[sentences]["embeddings"].values
 
-        # Normalise so that always has magnitude 1
+        # normalize embeddings to unit length (L2 norm)
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
 
         return embeddings
 
 class StackedModel(AbstractModel):
-  def __init__(self, model1: AbstractModel, model2: AbstractModel, task_name: str):
-      super().__init__(model_name=f"{model1.mode_name}${model2.mode_name}", task_name=task_name)
-      self.model_1 = model1
-      self.model_2 = model2
+    def __init__(self, model1: AbstractModel, model2: AbstractModel, task_name: str):
+        super().__init__(model_name=f"{model1.mode_name}${model2.mode_name}", task_name=task_name)
+        self.model_1 = model1
+        self.model_2 = model2
+        self.num_models = model1.num_models  + model2.num_models 
   
-  def encode(self, sentences, batch_size=32, **kwargs): 
-    emb1 = self.model_1.encode(sentences, batch_size)
-    emb2 = self.model_2.encode(sentences, batch_size)
-
-    concatination = np.concatenate((emb1, emb2), axis=1)
-
-    # Normalise so that always has magnitudhe 1
-    # TODO: This normalisation is wrong if magnitude if stack size > 3
-    concatination /= np.linalg.norm(concatination, axis=1, keepdims=True)
-    
-    return list(concatination)
+    def encode(self, sentences, batch_size=32, **kwargs):
+            emb1 = self.model_1.encode(sentences, batch_size)
+            emb2 = self.model_2.encode(sentences, batch_size)
+            concatenation = np.concatenate((emb1, emb2), axis=1)
+            return list(concatenation)
   
 def create_stacked_model(models, task_name):
     if len(models) == 1:
         return LocallyCachedModel(models[0], task_name)
-    return StackedModel(create_stacked_model(models[0:1], task_name), create_stacked_model(models[1:], task_name), task_name)
+    
+    stacked_model = stacked_model = StackedModel(create_stacked_model(models[0:1], task_name), create_stacked_model(models[1:], task_name), task_name)
+    
+    def normalize_encode(sentences, batch_size=32, **kwargs):
+        embeddings = stacked_model.encode(sentences, batch_size, **kwargs)
+        # Normalize the final stacked embeddings by dividing by the number of models
+        num_models = stacked_model.num_models
+        embeddings = [e / num_models for e in embeddings]
+        return embeddings
+    
+    stacked_model.encode = normalize_encode
+    return stacked_model
 
 def model_factory(model_name, task_name):
     if model_name in BASIC_MODELS:


### PR DESCRIPTION
- Every LocallyCachedModel has a `num_models` parameter
- Every base model is normalizes
- Within the process of stacking, no normalization occurs
- After the stacking process, we overwrite the `encode()` function to include the normalization

As each base model is normalized, the final stacked model will only need to be divided by the number of models stacked. This ensures we are within unit length